### PR TITLE
会話形式の振り返りの第一ステップ

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -32,7 +32,7 @@ class WebhookController < ApplicationController
             type: 'text',
             text: @response_text
           }
-          client.reply_message(event['replyToken'], message)          
+          client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])
           tf = Tempfile.open("content")

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -54,7 +54,8 @@ class WebhookController < ApplicationController
         'なぜそう感じたのだと思いますか？',
         'それを学びとして一文で表すとしたら、どのように人に教えますか？',
         '今日をもう一度やり直すとしたら、どうしますか？'
-      ]
+      ],
+      finishing: "これで質問は終了です\n明日も頑張りましょうね！"
     }
 
     case event.message['text']
@@ -62,6 +63,25 @@ class WebhookController < ApplicationController
       # 振り返りを始める（セッションを開始する）
       session[session_key] = { current_question: 1 }  # ユーザーごとに質問状態は異なる
       @response_text = "#{fixed_phrases[:greeting]} \n\n #{fixed_phrases[:questions][0]}"  # 挨拶＋最初の質問
+    else
+      if session[session_key]
+        user_session = session[session_key]
+      else
+        @response_text = '振り返りを開始するには「振り返り」と入力しましょう'
+        return
+      end
+      
+      # 質問を次に進める
+      next_question = user_session[:current_question] + 1
+      if next_question <= 5
+        user_session[:current_question] = next_question
+        session[session_key] = user_session  # 質問番号を更新
+        @response_text = "#{ fixed_phrases[:questions][user_session[:current_question] -  1] }"
+      else
+        # 全ての質問が終了
+        session[session_key] = nil
+        @response_text = "#{ fixed_phrases[:finishing] }"
+      end
     end
   end
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -27,6 +27,12 @@ class WebhookController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
           handle_text_message(event, session_key)
+
+          message = {
+            type: 'text',
+            text: @response_text
+          }
+          client.reply_message(event['replyToken'], message)          
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])
           tf = Tempfile.open("content")
@@ -55,16 +61,7 @@ class WebhookController < ApplicationController
     when '振り返り'
       # 振り返りを始める（セッションを開始する）
       session[session_key] = { current_question: 1 }  # ユーザーごとに質問状態は異なる
-      text = "#{fixed_phrases[:greeting]} \n\n #{fixed_phrases[:questions][0]}"  # 挨拶＋最初の質問
-      reply_text(event['replyToken'], text)
+      @response_text = "#{fixed_phrases[:greeting]} \n\n #{fixed_phrases[:questions][0]}"  # 挨拶＋最初の質問
     end
-  end
-  
-  def reply_text(reply_token, text)
-    message = {
-      type: 'text',
-      text: text
-    }
-    client.reply_message(reply_token, message)
   end
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -54,7 +54,7 @@ class WebhookController < ApplicationController
     case event.message['text']
     when '振り返り'
       # 振り返りを始める（セッションを開始する）
-      session[session_key] = { current_question: 1 }
+      session[session_key] = { current_question: 1 }  # ユーザーごとに質問状態は異なる
       text = "#{fixed_phrases[:greeting]} \n\n #{fixed_phrases[:questions][0]}"  # 挨拶＋最初の質問
       reply_text(event['replyToken'], text)
     end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -41,7 +41,7 @@ class WebhookController < ApplicationController
 
   def handle_text_message(event, session_key)
     fixed_phrases = {
-      greeting: "今日もお疲れさまです。振り返りを始めます。",
+      greeting: "今日もお疲れさまです。\n振り返りを始めます。",
       questions: [
         '今日絶対に達成したかったことはなんですか？',
         '今日どんな出来事があって、どう感じましたか？',

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -42,7 +42,7 @@ class WebhookController < ApplicationController
   def handle_text_message(event, session_key)
     fixed_phrases = {
       greeting: "今日もお疲れさまです。振り返りを始めます。",
-      questions = [
+      questions: [
         '今日絶対に達成したかったことはなんですか？',
         '今日どんな出来事があって、どう感じましたか？',
         'なぜそう感じたのだと思いますか？',
@@ -66,6 +66,5 @@ class WebhookController < ApplicationController
       text: text
     }
     client.reply_message(reply_token, message)
-    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.hosts << '.jp.ngrok.io'
+  config.hosts << '.ngrok-free.app'
 end


### PR DESCRIPTION
## 実装の背景・目的

会話形式で振り返りを行う。
セッションを用いることで、ユーザーにどこまで質問したのかをrails側で持つことができる。

## やったこと

- ユーザーが「振り返り」と発言すると、1個目の質問を送信する
  - 質問の途中でも関係なく、「振り返り」とユーザーが発言すると強制的に1個目の質問に戻る
  - ↑今は決め打ちの実装。DB保存等は無いので、バグではなく仕様としている

## キャプチャ

自分の実機で確認しました。

## 優先して確認してほしいこと

- 実装の仕方（書き方）でおかしい部分はないか
- ロジックの見落とし、不備等

## 補足

- すでにユーザーがセッションを持っている場合（＝振り返りが始まっている場合）、「振り返り」と発言しても反応しないようにしたい（する）

## TODO
- refactor
  - フレーズ選択のインデックス指定方法
  - 定数の位置、toUpperCase
  - インスタンス変数→明示的な値返却
  - 会話形式の分岐処理の切り出し